### PR TITLE
Added Vitis SDK path fix for cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ sudo apt install rsync
 
 ## Building the micro-ROS library
 
+Note - If Vitis SDK environment was sourced, the PATH will need to be adjusted.
+
+```bash
+export PATH="/usr/bin":$PATH
+```
 In order to generate the micro-ROS library for a specific target, the following command must be executed:
 
 ```bash


### PR DESCRIPTION
Sourcing the AMD Vitis SDK setup script will cause the PATH variable to change. We fix this with setting it to /usr/bin to pickup the right cmake tool.